### PR TITLE
fix(rapidpro): reorder poetry installation

### DIFF
--- a/roles/rapidpro/tasks/install.yml
+++ b/roles/rapidpro/tasks/install.yml
@@ -146,6 +146,19 @@
     replace: 'requires-python = ">=3.12,<3.{{ (ansible_python_version.split(''.'')[1] | int) + 1 }}"'
   become: yes
 
+- name: Install Poetry
+  shell: |
+    curl -sSL https://install.python-poetry.org | python3 -
+  args:
+    creates: "/home/{{ iiab_admin_user }}/.local/bin/poetry"
+  become: yes
+  become_user: "{{ iiab_admin_user }}"
+
+- name: Fix permissions on Poetry cache (fast)
+  command: "chown -R {{ iiab_admin_user }}:{{ iiab_admin_user }} /home/{{ iiab_admin_user }}/.cache/pypoetry"
+  become: yes
+  changed_when: false
+
 - name: Add missing regex dependency
   shell: |
     export PATH="/home/{{ iiab_admin_user }}/.local/bin:$PATH"
@@ -168,18 +181,7 @@
 
 
 
-- name: Install Poetry
-  shell: |
-    curl -sSL https://install.python-poetry.org | python3 -
-  args:
-    creates: "/home/{{ iiab_admin_user }}/.local/bin/poetry"
-  become: yes
-  become_user: "{{ iiab_admin_user }}"
 
-- name: Fix permissions on Poetry cache (fast)
-  command: "chown -R {{ iiab_admin_user }}:{{ iiab_admin_user }} /home/{{ iiab_admin_user }}/.cache/pypoetry"
-  become: yes
-  changed_when: false
 
 - name: Install Python dependencies with Poetry
   shell: |


### PR DESCRIPTION
Ensures poetry is installed before attempting to add dependencies (regex, gunicorn, celery), resolving a 'poetry: not found' error during installation.

### Fixes bug:

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
