### PR TITLE
fix(rapidpro): ensure services started before migrations on Android

### DIFF
--- a/roles/rapidpro/tasks/configure.yml
+++ b/roles/rapidpro/tasks/configure.yml
@@ -46,6 +46,16 @@
 
 
 
+- name: Force start postgresql for migrations (Android)
+  shell: /usr/local/bin/pdsm start postgresql
+  become: yes
+  when: ansible_service_mgr != 'systemd'
+
+- name: Force start valkey for migrations (Android)
+  shell: /usr/local/bin/pdsm start valkey
+  become: yes
+  when: ansible_service_mgr != 'systemd'
+
 - name: Run database migrations
   shell: |
     export PATH="/home/{{ iiab_admin_user }}/.local/bin:$PATH"


### PR DESCRIPTION
- Fix migration hang by force starting postgresql and valkey with pdsm

- Required because PRoot environment lacks automatic dependency management

### Fixes bug:

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
