### PR TITLE
fix(pdsm): rapidpro-dynamo auto-kill zombie process (port 4567)

### DIFF
--- a/roles/proot_services/templates/pdsm/rapidpro-dynamo.j2
+++ b/roles/proot_services/templates/pdsm/rapidpro-dynamo.j2
@@ -32,6 +32,14 @@ start() {
 
   echo "[pdsm:$SERVICE_NAME] starting..."
   
+  # aggressive cleanup of zombie processes holding the port
+  if fuser 4567/tcp >/dev/null 2>&1; then
+      echo "[pdsm:$SERVICE_NAME] Port 4567 in use, attempting cleanup..."
+      fuser -k 4567/tcp >/dev/null 2>&1 || true
+      pkill -f "dynalite" >/dev/null 2>&1 || true
+      sleep 2
+  fi
+
   # Ensure log ownership
   chown {{ iiab_admin_user }}:{{ iiab_admin_user }} "$LOGFILE" 2>/dev/null || true
 


### PR DESCRIPTION
### Fixes bug:

### Description of changes proposed in this pull request:

### Smoke-tested on which OS or OS's:

### Mention a team member @username e.g. to help with code review:
